### PR TITLE
fix: removed whitespace from the creation of the RDF namespace

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,6 +1,6 @@
 import namespace from '@rdfjs/namespace'
 
-const rdf = namespace(' http://www.w3.org/1999/02/22-rdf-syntax-ns#')
+const rdf = namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
 
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdfjs/serializer-turtle",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Turtle serializer that implements the RDF/JS Sink interface",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Removed whitespace from the creation of the RDF namespace, as described by this issue: https://github.com/rdfjs-base/serializer-turtle/issues/14